### PR TITLE
Fetch english title from the main title section

### DIFF
--- a/Emby.Plugins.MyAnimeList/api.cs
+++ b/Emby.Plugins.MyAnimeList/api.cs
@@ -69,25 +69,27 @@ namespace Emby.Plugins.MyAnimeList
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public string SelectName(string WebContent, string preferredMetadataLanguage)
-        {
+        {   
+            var title;
             if (string.IsNullOrEmpty(preferredMetadataLanguage) || preferredMetadataLanguage.StartsWith("en", StringComparison.OrdinalIgnoreCase))
             {
-                var title = Get_title("en", WebContent);
-                if (!string.IsNullOrWhiteSpace(title))
+                title = Get_title("en", WebContent);
+                if (string.IsNullOrWhiteSpace(title))
                 {
-                    return title;
+                    title = Get_title("en_alt", WebContent);
                 }
             }
             if (string.Equals(preferredMetadataLanguage, "ja", StringComparison.OrdinalIgnoreCase))
             {
-                var title = Get_title("jap", WebContent);
-                if (!string.IsNullOrWhiteSpace(title))
-                {
-                    return title;
-                }
+                title = Get_title("jap", WebContent);
+            }
+            //Default to romanji title
+            if (string.IsNullOrWhiteSpace(title))
+            {
+                title = Get_title("jap_r", WebContent);
             }
 
-            return Get_title("jap_r", WebContent);
+            return title;
         }
 
         /// <summary>
@@ -101,13 +103,10 @@ namespace Emby.Plugins.MyAnimeList
             switch (lang)
             {
                 case "en":
-                    var en_title = WebUtility.HtmlDecode(One_line_regex(new Regex(@">([\S\s]*?)<"), One_line_regex(new Regex(@"English:<\/span>(?s)(.*?)<"), WebContent)));
+                    return WebUtility.HtmlDecode(One_line_regex(new Regex("<p class="title-english title-inherit">" + @"(.*?)<"), WebContent));
 
-                    //Get English title from the main title section if it's not defined in the alternative titles
-                    if (string.IsNullOrWhiteSpace(en_title))
-                    {
-                        return WebUtility.HtmlDecode(One_line_regex(new Regex("<p class="title-english title-inherit">" + @"(.*?)<"), WebContent));
-                    }
+                case "en_alt":
+                    return WebUtility.HtmlDecode(One_line_regex(new Regex(@">([\S\s]*?)<"), One_line_regex(new Regex(@"English:<\/span>(?s)(.*?)<"), WebContent)));
 
                 case "jap":
                     return WebUtility.HtmlDecode(One_line_regex(new Regex(@">([\S\s]*?)<"), One_line_regex(new Regex(@"Japanese:<\/span>(?s)(.*?)<"), WebContent)));

--- a/Emby.Plugins.MyAnimeList/api.cs
+++ b/Emby.Plugins.MyAnimeList/api.cs
@@ -101,7 +101,13 @@ namespace Emby.Plugins.MyAnimeList
             switch (lang)
             {
                 case "en":
-                    return WebUtility.HtmlDecode(One_line_regex(new Regex(@">([\S\s]*?)<"), One_line_regex(new Regex(@"English:<\/span>(?s)(.*?)<"), WebContent)));
+                    var en_title = WebUtility.HtmlDecode(One_line_regex(new Regex(@">([\S\s]*?)<"), One_line_regex(new Regex(@"English:<\/span>(?s)(.*?)<"), WebContent)));
+
+                    //Get English title from the main title section if it's not defined in the alternative titles
+                    if (string.IsNullOrWhiteSpace(en_title))
+                    {
+                        return WebUtility.HtmlDecode(One_line_regex(new Regex("<p class="title-english title-inherit">" + @"(.*?)<"), WebContent));
+                    }
 
                 case "jap":
                     return WebUtility.HtmlDecode(One_line_regex(new Regex(@">([\S\s]*?)<"), One_line_regex(new Regex(@"Japanese:<\/span>(?s)(.*?)<"), WebContent)));


### PR DESCRIPTION
The english title is rarely present in the "alternative titles" section, which defaults the plugin to the romanji title. This PR makes the plugin check regular english title by default and alternative one if regular is not present