### PR TITLE
New MAL API + refactoring

### DIFF
--- a/Emby.Plugins.MyAnimeList/ApiModel.cs
+++ b/Emby.Plugins.MyAnimeList/ApiModel.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+
+namespace Emby.Plugins.MyAnimeList
+{
+    public class AlternativeTitles
+    {
+        public List<string> synonyms { get; set; }
+        public string en { get; set; }
+        public string ja { get; set; }
+    }
+
+    public class Picture
+    {
+        public string medium { get; set; }
+        public string large { get; set; }
+    }
+
+    public class SerchNode
+    {
+        public int id { get; set; }
+        public string title { get; set; }
+        public Picture main_picture { get; set; }
+        public AlternativeTitles alternative_titles { get; set; }
+    }
+
+    public class SearchData
+    {
+        public SerchNode node { get; set; }
+    }
+
+    public class SearchObject
+    {
+        public List<SearchData> data { get; set; }
+    }
+    public class Genre
+    {
+        public int id { get; set; }
+        public string name { get; set; }
+    }
+
+    public class Studio
+    {
+        public int id { get; set; }
+        public string name { get; set; }
+    }
+
+    public class AnimeObject
+    {
+        public int id { get; set; }
+        public string title { get; set; }
+        public Picture main_picture { get; set; }
+        public AlternativeTitles alternative_titles { get; set; }
+        public string start_date { get; set; }
+        public string end_date { get; set; }
+        public string synopsis { get; set; }
+        public float mean { get; set; }
+        public string status { get; set; }
+        public List<Genre> genres { get; set; }
+        public string source { get; set; }
+        public List<Picture> pictures { get; set; }
+        public string background { get; set; }
+        public List<Studio> studios { get; set; }
+    }
+}

--- a/Emby.Plugins.MyAnimeList/Configuration/myanimelist.html
+++ b/Emby.Plugins.MyAnimeList/Configuration/myanimelist.html
@@ -2,19 +2,8 @@
     <div class="scrollSlider flex-grow flex-direction-column padded-left padded-left-page padded-right padded-top-page padded-bottom-page">
 
         <form class="auto-center">
-            <div style="height:0; overflow: hidden;"><input type="text" name="fakeusernameremembered" tabindex="-1" /><input type="password" name="fakepasswordremembered" tabindex="-1" /></div>
-
-            <div style="display: none;">
-                <input type="text" id="PreventChromeAutocomplete" name="PreventChromeAutocomplete" autocomplete="address-level4" />
-            </div>
-
-
             <div class="inputContainer">
-                <input is="emby-input" type="text" id="txtUsername" autocomplete="off" label="MyAnimeList API Username:" />
-            </div>
-
-            <div class="inputContainer">
-                <input is="emby-input" type="password" id="txtPassword" autocomplete="off" label="MyAnimeList API Password:" />
+                <input is="emby-input" type="text" id="clientID" label="MyAnimeList API Client ID:" />
             </div>
 
             <div>

--- a/Emby.Plugins.MyAnimeList/Configuration/myanimelist.js
+++ b/Emby.Plugins.MyAnimeList/Configuration/myanimelist.js
@@ -3,8 +3,7 @@
 
     function loadPage(page, config) {
 
-        page.querySelector('#txtUsername').value = config.Username || '';
-        page.querySelector('#txtPassword').value = config.Password || '';
+        page.querySelector('#clientID').value = config.ClientID || '';
 
         loading.hide();
     }
@@ -19,8 +18,7 @@
 
         ApiClient.getNamedConfiguration("myanimelist").then(function (config) {
 
-            config.Username = form.querySelector('#txtUsername').value;
-            config.Password = form.querySelector('#txtPassword').value;
+            config.ClientID = form.querySelector('#clientID').value;
 
             ApiClient.updateNamedConfiguration("myanimelist", config).then(Dashboard.processServerConfigurationUpdateResult);
         });

--- a/Emby.Plugins.MyAnimeList/ConfigurationExtension.cs
+++ b/Emby.Plugins.MyAnimeList/ConfigurationExtension.cs
@@ -29,7 +29,7 @@ namespace Emby.Plugins.MyAnimeList
 
     public class MyAnimeListOptions
     {
-        public string Username { get; set; }
-        public string Password { get; set; }
+        public string ClientID { get; set; }
+
     }
 }

--- a/Emby.Plugins.MyAnimeList/equals_check.cs
+++ b/Emby.Plugins.MyAnimeList/equals_check.cs
@@ -68,6 +68,7 @@ namespace Emby.Plugins.MyAnimeList
             a = a.Replace("-", " ", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("`", "", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("'", "", StringComparison.OrdinalIgnoreCase);
+            a = a.Replace("’", "", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("&", "and", StringComparison.OrdinalIgnoreCase);
             a = a.Replace(":", "", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("␣", "", StringComparison.OrdinalIgnoreCase);

--- a/Emby.Plugins.MyAnimeList/equals_check.cs
+++ b/Emby.Plugins.MyAnimeList/equals_check.cs
@@ -35,6 +35,8 @@ namespace Emby.Plugins.MyAnimeList
         public static string Clear_name(string a)
         {
             a = a.Trim().ReplaceSafe(One_line_regex(new Regex(@"(?s) \(.*?\)"), a.Trim(), 0), "", StringComparison.OrdinalIgnoreCase);
+            a = a.Trim().ReplaceSafe(One_line_regex(new Regex(@"(?s) \[tvdb.*?\]"), a.Trim(), 0), "", StringComparison.OrdinalIgnoreCase);
+            a = a.Trim().ReplaceSafe(One_line_regex(new Regex(@"(?s) \{tvdb.*?\}"), a.Trim(), 0), "", StringComparison.OrdinalIgnoreCase);
 
             a = a.Replace(".", " ", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("-", " ", StringComparison.OrdinalIgnoreCase);
@@ -65,6 +67,8 @@ namespace Emby.Plugins.MyAnimeList
             a = a.Trim().ReplaceSafe(One_line_regex(new Regex(@"(?s) \(.*?\)"), a.Trim(), 0), "", StringComparison.OrdinalIgnoreCase);
 
             a = a.Replace(".", " ", StringComparison.OrdinalIgnoreCase);
+            a = a.Replace("!", " ", StringComparison.OrdinalIgnoreCase);
+            a = a.Replace("?", " ", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("-", " ", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("`", "", StringComparison.OrdinalIgnoreCase);
             a = a.Replace("'", "", StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
The old MAL API was shut down many years ago. This MR implements a new API (https://myanimelist.net/apiconfig/references/api/v2) while keeping web scraping fallback intact.
To use the new MAL API users must create a new client in their account settings (https://myanimelist.net/apiconfig) and set Client ID in the plugin settings.