### PR TITLE
Limit title length to 64 when searching for a series

### DIFF
--- a/Emby.Plugins.MyAnimeList/Emby.Plugins.MyAnimeList.csproj
+++ b/Emby.Plugins.MyAnimeList/Emby.Plugins.MyAnimeList.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;</TargetFrameworks>
-    <AssemblyVersion>1.0.13.0</AssemblyVersion>
-    <FileVersion>1.0.13.0</FileVersion>
+    <AssemblyVersion>1.0.14.0</AssemblyVersion>
+    <FileVersion>1.0.14.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,5 +22,5 @@
     <PackageReference Include="mediabrowser.server.core" Version="4.8.11" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
-
+	
 </Project>

--- a/Emby.Plugins.MyAnimeList/api.cs
+++ b/Emby.Plugins.MyAnimeList/api.cs
@@ -342,7 +342,7 @@ namespace Emby.Plugins.MyAnimeList
             //API
             if (!string.IsNullOrEmpty(clientID))
             {
-                string json = await WebRequestAPI(string.Format(SearchLink, Uri.EscapeUriString(title)), cancellationToken, clientID).ConfigureAwait(false);
+                string json = await WebRequestAPI(string.Format(SearchLink, Uri.EscapeUriString(TruncateTo64(title))), cancellationToken, clientID).ConfigureAwait(false);
                 SearchObject search = _jsonSerializer.DeserializeFromString<SearchObject>(json);
                 foreach (SearchData data in search.data)
                 {
@@ -369,7 +369,7 @@ namespace Emby.Plugins.MyAnimeList
             else
             {
                 //Fallback to Web
-                string WebContent = await WebRequestAPI(string.Format(FallbackSearchLink, Uri.EscapeUriString(title)), cancellationToken).ConfigureAwait(false);
+                string WebContent = await WebRequestAPI(string.Format(FallbackSearchLink, Uri.EscapeUriString(TruncateTo64(title))), cancellationToken).ConfigureAwait(false);
                 string regex_id = "-";
                 int x = 0;
                 while (!string.IsNullOrEmpty(regex_id) && x < 50)
@@ -486,6 +486,14 @@ namespace Emby.Plugins.MyAnimeList
 
                 return string.Empty;
             }
+        }
+
+        /// MAL API supports max 64 character queries
+        public static string TruncateTo64(string value)
+        {
+            return value.Length > 64
+                ? value.Substring(0, 64)
+                : value;
         }
     }
 }


### PR DESCRIPTION
MAL API search requests fail if the query is longer than 64 characters. This MR fixes this issue.